### PR TITLE
Add FastAPI backend for audio processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # research
 
 このソフトウェアは大学生のためのツールです。
+
+## Backend
+
+Install dependencies and run the development server:
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,51 @@
+from fastapi import FastAPI, UploadFile, File, BackgroundTasks
+from fastapi.responses import FileResponse
+from gtts import gTTS
+import os
+import tempfile
+
+try:
+    import speech_recognition as sr
+except ImportError:  # optional dependency
+    sr = None
+
+app = FastAPI()
+
+@app.post("/process_audio")
+async def process_audio(background_tasks: BackgroundTasks, file: UploadFile = File(...)):
+    """Accept an audio file, optionally transcribe it and return a TTS response."""
+    # Save uploaded audio to a temporary file
+    suffix = os.path.splitext(file.filename)[1]
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_in:
+        content = await file.read()
+        temp_in.write(content)
+        temp_audio_path = temp_in.name
+
+    transcript = ""
+    if sr:
+        recognizer = sr.Recognizer()
+        with sr.AudioFile(temp_audio_path) as source:
+            audio_data = recognizer.record(source)
+        try:
+            transcript = recognizer.recognize_google(audio_data, language="en-US")
+        except sr.UnknownValueError:
+            pass
+        except sr.RequestError:
+            pass
+
+    # Remove the uploaded temp file
+    os.remove(temp_audio_path)
+
+    response_text = f"You said: {transcript}" if transcript else "Hello!"
+
+    # Generate speech
+    tts = gTTS(response_text, lang="en")
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as temp_out:
+        tts.save(temp_out.name)
+        tts_path = temp_out.name
+
+    # Schedule temp file cleanup after response is sent
+    background_tasks.add_task(os.remove, tts_path)
+
+    return FileResponse(tts_path, media_type="audio/mpeg", filename="response.mp3")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+gTTS


### PR DESCRIPTION
## Summary
- add minimal FastAPI app with `/process_audio` endpoint
- return gTTS synthesized response
- document running backend
- add requirements for backend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a9d84346c83329fd413b293cfec58